### PR TITLE
burgerMenu: scrollbar show & hide default boundary as noted in issues/47

### DIFF
--- a/src/components/Navbar/BurgerMenu.js
+++ b/src/components/Navbar/BurgerMenu.js
@@ -1,66 +1,65 @@
 import React from "react";
 import { slide as Menu } from 'react-burger-menu';
-export default function BurgerMenu (props) {
- console.log(props)
-var styles = {
-  bmBurgerButton: {
-    position: 'fixed',
-    width: '36px',
-    height: '30px',
-    left: props.burgerMenuButtonPosition,
-    top: '10px'
-  },
-  bmBurgerBars: {
-    background: '#373a47'
-  },
-  bmCrossButton: {
-    height: '24px',
-    width: '24px'
-  },
-  bmCross: {
-    background: '#bdc3c7'
-  },
-  bmMenuWrap: {
-    position: 'fixed',
+export default function BurgerMenu(props) {
+
+  var styles = {
+    bmBurgerButton: {
+      position: 'fixed',
+      width: '36px',
+      height: '30px',
+      left: props.burgerMenuButtonPosition,
+      top: '10px'
+    },
+    bmBurgerBars: {
+      background: '#373a47'
+    },
+    bmCrossButton: {
+      height: '24px',
+      width: '24px'
+    },
+    bmCross: {
+      background: '#bdc3c7'
+    },
+    bmMenuWrap: {
+      position: 'fixed',
       height: '100%',
-    width: props.sideBarWidth, 
-  },
-  bmMenu: {
-    background: '#FFFFFF',
-    padding: '2.5em 1.5em 0',
-    width: props.sideBarWidth,
+      width: props.sideBarWidth,
+    },
+    bmMenu: {
+      background: '#FFFFFF',
+      padding: '2.5em 1.5em 0',
+      width: props.sideBarWidth,
       minWidth: '140px',
       maxWidth: '300px',
-    fontSize: '1.15em',
-    overflowY: 'hidden',
-    marginTop: '2px',
-    padding: '0px',
-    boxShadow: "4px 2px 4px rgba(0, 0, 0, 0.3)",
-    padding: "0",
-    margin: "0",
-    
-  },
-  bmMorphShape: {
-    fill: '#373a47'
-  },
-  bmItemList: {
-    color: '#b8b7ad',
-    width: props.sideBarWidth,
-     padding: "0",
-     margin: "0",
-    display:'block'
-  },
-  bmItem: {
-        marginRight: "2px",
-  },
-  bmOverlay: {
-    background: 'rgba(0, 0, 0, 0.3)'
-  }
-}
-    return (
-        <Menu styles ={ styles }>
-            {props.children}
-      </Menu>
-    );
+      fontSize: '1.15em',
+      marginTop: '2px',
+      padding: '0px',
+      boxShadow: "4px 2px 4px rgba(0, 0, 0, 0.3)",
+      padding: "0",
+      margin: "0",
+    },
+    bmMorphShape: {
+      fill: '#373a47'
+    },
+    bmItemList: {
+      color: '#b8b7ad',
+      width: props.sideBarWidth,
+      padding: "0",
+      margin: "0",
+      display: 'block'
+    },
+    bmItem: {
+      marginRight: "2px",
+      outline: "none",
+    },
+    bmOverlay: {
+      background: 'rgba(0, 0, 0, 0.3)'
+    }
   }
 
+  return (
+    <Menu styles={styles}>
+      {props.children}
+    </Menu>
+  );
+}


### PR DESCRIPTION
NOTE: view diff with "ignore whitespaces" bcos I formatted the file too

Observed another issue: burgerMenu react component is adding tabIndex so we need to handle an open event to set it to -1 (right now, would need to press tab key twice)